### PR TITLE
Ensure non-zero return code on test failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,5 @@ module.exports = (results) => {
   const testSuites = new Testsuites(results);
   const data = xml(testSuites, { declaration: true, indent: '  ' });
   fs.writeFileSync(`${out}/test-report.xml`, data);
+  return results;
 };

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -37,3 +37,9 @@ it('should produce a valid JUnit XML report', () => {
   const errors = schema.validate(report);
   expect(errors).toBeNull();
 });
+
+it('should return given test results', () => {
+  const returnedResults = reporter(mock);
+  expect(returnedResults).toEqual(mock);
+});
+


### PR DESCRIPTION
If we don't return results back to jest then jest will return a zero return code indicating that no errors have occured. This is problematic because it makes it impossible to know if the tests failed in CI systems and act accordingly (e.g. break a CI pipeline).

This commit ensures jest is made aware of the errors and returns a non-zero return code if a test fails. This makes it possible to utilise the jest return code in a CI system.